### PR TITLE
feat: Support for templateAlias in Postmark

### DIFF
--- a/src/transporters/postmark/postmark.class.ts
+++ b/src/transporters/postmark/postmark.class.ts
@@ -54,9 +54,21 @@ export class PostmarkTransporter extends Transporter {
     switch(payload.compiler.valueOf()) {
       case COMPILER.provider:
         Object.assign(output, {
-          templateModel: payload.data,
-          templateId: payload.meta.templateId || parseInt(templateId, 10)
-        });
+                    templateModel: payload.data
+                });
+
+        //setting templateId or templateAlias based on the data set
+        const tempId = payload.meta.templateId || templateId;
+
+        if(isNaN(tempId)) {
+            Object.assign(output, {
+                templateAlias: tempId
+            });
+        } else {
+            Object.assign(output, {
+                templateId: tempId
+            });
+        };
         break;
       case COMPILER.default:
       case COMPILER.self:


### PR DESCRIPTION
Added support for templateAlias in postmark transporter. 
Now if it's a number, it considers as templateId, else, templateAlias.

Template Alias are very handy and readable compared to template Id's.